### PR TITLE
Supports checkbox+hidden input with identical name

### DIFF
--- a/src/jquery.loadJSON.js
+++ b/src/jquery.loadJSON.js
@@ -270,7 +270,10 @@
 					///nova dva reda
 					setElementValue(element, obj, name);
 					return;
-
+				} else if (element.length > 0 && element.filter('input:hidden').length > 0 && element.filter(':checkbox').length > 0) {
+					element.filter(':checkbox').each(function () {
+						setElementValue(this, obj, name);
+					});
 				} else if (element.length > 0 && element[0].type == 'checkbox') {
 					element.each(function() {
 						setElementValue(this, obj, name);
@@ -318,11 +321,14 @@
 				var value = obj;
 				var type;
 				if (element.length > 0) {
-					var i = 0;
-					for (i = 0; i < element.length; i++) {
-						setElementValue(element[i], obj, name);
+					if (element.filter('input:hidden').length > 0 && element.filter(':checkbox').length > 0) {
+						setElementValue(element.filter(':checkbox').first()[0], obj, name);
+					} else {
+						var i = 0;
+						for (i = 0; i < element.length; i++) {
+							setElementValue(element[i], obj, name);
+						}
 					}
-
 				} else {
 					setElementValue(element, obj, name);
 				}


### PR DESCRIPTION
This enhancement/fix to support the scenario where the library does not work as expected. 

In essence, with the following (for the purpose of having a default value instead of "XXX" when no checkbox is selected), jquery-load-json does not work.  

``` html
<input type="checkbox" name="PreferencePrimary" value="P1" />P1
<input type="checkbox" name="PreferencePrimary" value="P2" />P2
<input type="hidden" name="PreferencePrimary" value="XXX" />
```

1) This is done when the requirement is for the underlying bool field to be tri-state (null, false, true).  I.e. We need to differentiate between no value submitted vs checkbox not being checked in other scenarios.

2) MVC.net also generates similar html code (http://stackoverflow.com/questions/2697299/asp-net-mvc-why-is-html-checkbox-generating-an-additional-hidden-input)
